### PR TITLE
29 add neck kinematics

### DIFF
--- a/reachy_sdk/head.py
+++ b/reachy_sdk/head.py
@@ -8,7 +8,6 @@ Handles all specific method to an Head:
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
-from scipy.spatial.transform import Rotation
 
 from pyquaternion import Quaternion
 
@@ -43,7 +42,6 @@ class Head:
 
     def __init__(self, joints: List[Joint], grpc_channel) -> None:
         """Set up the head."""
-
         self._kin_stub = HeadKinematicsStub(grpc_channel)
 
         def get_joint(name):
@@ -114,7 +112,6 @@ class Head:
 
         You can also specify a basic joint configuration as a prior for the solution.
         """
-
         if q0 is not None and (len(q0) != len(self._kinematics_chain)):
             raise ValueError(f'q0 should be length {len(self._kinematics_chain)} (got {len(q0)} instead)!')
 

--- a/reachy_sdk/head.py
+++ b/reachy_sdk/head.py
@@ -196,7 +196,6 @@ class Head:
         q = _find_quaternion_transform([1, 0, 0], [x, y, z])
 
         neckik = self.inverse_kinematics(q)
-        # roll, pitch, yaw = np.rad2deg(Rotation.from_quat(q).as_euler('XYZ'))
         roll, pitch, yaw = neckik[0], neckik[1], neckik[2]
         goal_positions = {
             self.joints.neck_roll: roll,
@@ -212,7 +211,6 @@ def _find_quaternion_transform(
 ) -> Tuple[float, float, float, float]:
 
     vo = _norm(vect_origin)
-    # vd = _norm(vect_dest)
 
     # ad-hoc translation to move in the torso frame (from urdf)
     orbita_in_torso = (vect_dest[0]-0.015, vect_dest[1], vect_dest[2]-0.095)

--- a/reachy_sdk/head.py
+++ b/reachy_sdk/head.py
@@ -12,10 +12,21 @@ from scipy.spatial.transform import Rotation
 
 from pyquaternion import Quaternion
 
+from reachy_sdk_api.head_kinematics_pb2_grpc import HeadKinematicsStub
+from reachy_sdk_api.head_kinematics_pb2 import HeadFKRequest, HeadIKRequest
+from reachy_sdk_api.kinematics_pb2 import joint__pb2
+from reachy_sdk_api.arm_kinematics_pb2 import kinematics__pb2
+
 from .device_holder import DeviceHolder
 from .joint import Joint
 from .trajectory import goto, goto_async
 from .trajectory.interpolation import InterpolationMode
+
+
+JointId = joint__pb2.JointId
+JointPosition = kinematics__pb2.JointPosition
+Matrix4x4 = kinematics__pb2.Matrix4x4
+QuaternionPb = kinematics__pb2.Quaternion
 
 
 class Head:
@@ -33,6 +44,8 @@ class Head:
     def __init__(self, joints: List[Joint], grpc_channel) -> None:
         """Set up the head."""
 
+        self._kin_stub = HeadKinematicsStub(grpc_channel)
+
         def get_joint(name):
             for j in joints:
                 if j.name == name:
@@ -42,7 +55,8 @@ class Head:
 
         if len(found_joints) != len(self._required_joints):
             raise ValueError(f'Required joints not found {self._required_joints}')
-
+        self._kinematics_chain = ['neck_roll', 'neck_pitch', 'neck_yaw']
+        self.kinematics_chain = DeviceHolder([j for j in found_joints if j.name in self._kinematics_chain])
         self.joints = DeviceHolder(found_joints)
         self._setup_joints(found_joints)
 
@@ -59,6 +73,79 @@ class Head:
         for j in joints:
             if j.name in self._required_joints:
                 setattr(self, j.name, j)
+
+    def forward_kinematics(self, joints_position: Optional[List[float]] = None) -> Tuple[float, float, float, float]:
+        """Compute the forward kinematics of the head.
+
+        It will return the quaternion (x, y, z, w).
+        You can either specify a given joints position, otherwise it will use the current robot position.
+        """
+        if joints_position is None:
+            joints_position = [j.present_position for j in self.kinematics_chain.values()]
+
+        if isinstance(joints_position, np.ndarray) and len(joints_position.shape) > 1:
+            raise ValueError('Vectorized kinematics not supported!')
+
+        pos = np.deg2rad(list(joints_position))
+
+        if len(pos) != len(self._kinematics_chain):
+            raise ValueError(
+                f'joints_position should be length {len(self._kinematics_chain)} (got {len(pos)} instead)!'
+            )
+
+        req = HeadFKRequest(
+            neck_position=self._joint_position_from_pos(pos),
+
+        )
+        resp = self._kin_stub.ComputeHeadFK(req)
+        if not resp.success:
+            raise ValueError(f'No solution found for the given joints ({joints_position})!')
+
+        return (resp.q.x, resp.q.y, resp.q.z, resp.q.w)
+
+    def inverse_kinematics(self, target: Tuple[float, float, float, float], q0: Optional[List[float]] = None) -> List[float]:
+        """Compute the inverse kinematics of the arm.
+
+        Given a goal quaternion (x, y, z, w)
+        it will try to compute a joint solution to reach this target (or get close).
+
+        It will raise a ValueError if no solution is found.
+
+        You can also specify a basic joint configuration as a prior for the solution.
+        """
+
+        if q0 is not None and (len(q0) != len(self._kinematics_chain)):
+            raise ValueError(f'q0 should be length {len(self._kinematics_chain)} (got {len(q0)} instead)!')
+
+        if isinstance(q0, np.ndarray) and len(q0.shape) > 1:
+            raise ValueError('Vectorized kinematics not supported!')
+
+        qr = QuaternionPb()
+        qr.x = target[0]
+        qr.y = target[1]
+        qr.z = target[2]
+        qr.w = target[3]
+
+        req_params = {
+            'q': qr
+        }
+
+        if q0 is not None:
+            req_params['q0'] = self._joint_position_from_pos(np.deg2rad(q0))
+
+        req = HeadIKRequest(**req_params)
+        resp = self._kin_stub.ComputeHeadIK(req)
+
+        if not resp.success:
+            raise ValueError(f'No solution found for the given target ({target})!')
+
+        return np.rad2deg(resp.neck_position.positions.positions).tolist()
+
+    def _joint_position_from_pos(self, joints_position: List[float]) -> JointPosition:
+        return JointPosition(
+            ids=[JointId(uid=j.uid) for j in self.kinematics_chain.values()],
+            positions=joints_position,
+        )
 
     async def look_at_async(
         self,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         'numpy',
         'opencv-python',
-        'reachy-sdk-api',
+        'reachy-sdk-api>=0.7.0',
         'grpcio>=1.37',
         'protobuf>3',
         'pyquaternion',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='reachy-sdk',
-    version='0.5.4',
+    version='0.7.0',
     packages=find_packages(exclude=['tests']),
 
     install_requires=[


### PR DESCRIPTION
### Identify the Bug (if you are fixing one)

Changes synced with this issue:
pollen-robotics/reachy_2023/issues/29

### Description of the Change

Change the way the neck is controlled, we now use the kdl kinematics to control the head_tip rather than Orbita directly. This is more generic and allows for easier change in the Orbita kinematics.

### Possible Drawbacks

Unfortunately it might change some behavior...

### Release Notes

Change the control of the neck. We can now control the head_tip with the look_at and we have access to forward and inverse kinematics for the head.