### PR TITLE
enhancement #51: added set_torques function

### DIFF
--- a/reachy_sdk/reachy_sdk.py
+++ b/reachy_sdk/reachy_sdk.py
@@ -320,14 +320,14 @@ class ReachySDK:
         for joint in req_part.joints.values():
             joint.torque_limit = 100.0
 
-    def set_torques(self, part, percent: float = 100.0):
+    def _set_torques(self, part, percent: float = 100.0):
         """Set the torque_limit of the given Reachy's part. Use a value between 0 and 100.
 
         The requested part can be 'l_arm', 'r_arm', 'head' or 'reachy'.
         Having part = 'reachy' corresponds to turning all avaible joints compliant.
         """
         if part not in [p.name.lower() for p in ReachyParts]:
-            raise ValueError("Part to turn on/off should be either 'reachy', 'l_arm', 'r_arm' or 'head'.")
+            raise ValueError("Can only change the torque to either 'reachy', 'l_arm', 'r_arm' or 'head'.")
 
         if part == 'reachy':
             req_part = self

--- a/reachy_sdk/reachy_sdk.py
+++ b/reachy_sdk/reachy_sdk.py
@@ -320,6 +320,28 @@ class ReachySDK:
         for joint in req_part.joints.values():
             joint.torque_limit = 100.0
 
+    def set_torques(self, part, percent: float = 100.0):
+        """Set the torque_limit of the given Reachy's part. Use a value between 0 and 100.
+
+        The requested part can be 'l_arm', 'r_arm', 'head' or 'reachy'.
+        Having part = 'reachy' corresponds to turning all avaible joints compliant.
+        """
+        if part not in [p.name.lower() for p in ReachyParts]:
+            raise ValueError("Part to turn on/off should be either 'reachy', 'l_arm', 'r_arm' or 'head'.")
+
+        if part == 'reachy':
+            req_part = self
+        else:
+            req_part = getattr(self, part)
+
+        if percent > 100.0:
+            percent = 100.0
+        elif percent < 0.0:
+            percent = 0.0
+
+        for joint in req_part.joints.values():
+            joint.torque_limit = percent
+
     def _restart(self):
         self._restart_signal_stub.SendRestartSignal(
             restart_signal_pb2.RestartCmd(


### PR DESCRIPTION
### Requirements for Contributing

* Fill out the template below.


### Identify the Bug (if you are fixing one)
Fixes #51 

### Description of the Change
Added a simple function "set_torques". The function sets the torque_limit of the given Reachy's part (between 0% and 100%).
This function works in a similar fashion to turn_on and turn_off regarding its "parts" input (The requested part can be 'l_arm', 'r_arm', 'head' or 'reachy').
Performed a few tests on a physical Reachy during grasping tests here:
https://github.com/pollen-robotics/simple_grasp_pipe/blob/master/simple_grasp_pipe/simple_grasp_pipe.py

=> The main motivation for this function was to "fix" the robot's state that occurs when the program is killed before a turn_off_smoothly is finished, which led to all the torques being set to 0.

### Possible Drawbacks
Server overcharge due to an overwhelming amount of new users.
### Release Notes
Added a simple function "set_torques(pert, percent)" to set all torques of a given part easily.
