### PR TITLE
Get config from grpc method. Adapt head required joints with the config.

### DIFF
--- a/reachy_sdk/head.py
+++ b/reachy_sdk/head.py
@@ -36,12 +36,17 @@ class Head:
     expressed in Reachy's coordinate system.
     """
 
-    _required_joints = (
-        'neck_roll', 'neck_pitch', 'neck_yaw', 'l_antenna', 'r_antenna',
-    )
-
-    def __init__(self, joints: List[Joint], grpc_channel) -> None:
+    def __init__(self, config, joints: List[Joint], grpc_channel) -> None:
         """Set up the head."""
+        if 'no_head' in config:
+            self._required_joints = (
+                'neck_roll', 'neck_pitch', 'neck_yaw',
+            )
+        else:
+            self._required_joints = (
+                'neck_roll', 'neck_pitch', 'neck_yaw', 'l_antenna', 'r_antenna',
+            )
+
         self._kin_stub = HeadKinematicsStub(grpc_channel)
 
         def get_joint(name):


### PR DESCRIPTION
Use the grpc method GetReachyConfig to get the robot config.
The config is used in setup_head to adapt the required joints depending on the robot config. For custom config like *starter_kit_no_head*, the required joints should not include the antennas for example.
Did you think about other places where we should use the fact of having the config of the robot @pierre-rouanet ?