### PR TITLE
Add "f" for proper formatting of ValueError message in goto_async

### DIFF
--- a/reachy_sdk/trajectory/__init__.py
+++ b/reachy_sdk/trajectory/__init__.py
@@ -87,7 +87,7 @@ async def goto_async(
 
     length = round(duration * sampling_freq)
     if length < 1:
-        raise ValueError('Goto length too short! (incoherent duration {duration} or sampling_freq {sampling_freq})!')
+        raise ValueError(f'Goto length too short! (incoherent duration {duration} or sampling_freq {sampling_freq})!')
 
     joints = starting_positions.keys()
     dt = 1 / sampling_freq


### PR DESCRIPTION
Fixed a formatting issue in the ValueError exception message.  Added an "f" at the beginning of the string to enable variable interpolation in the error message.
